### PR TITLE
Security Fix - Updated lodash version to 4.17.19

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -65,6 +65,7 @@
     "clsx": "^1.1.0",
     "css-loader": "^3.5.3",
     "dotenv": "^8.0.0",
+    "lodash": "^4.17.19",
     "next-redux-wrapper": "^3.0.0-alpha.3",
     "node-sass": "^4.14.1",
     "ramda": "^0.26.1",

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -7615,6 +7615,11 @@ lodash.uniq@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
   integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
 
+lodash@^4.17.19:
+  version "4.17.19"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.19.tgz#e48ddedbe30b3321783c5b4301fbd353bc1e4a4b"
+  integrity sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==
+
 loglevel@^1.6.6:
   version "1.6.7"
   resolved "https://registry.yarnpkg.com/loglevel/-/loglevel-1.6.7.tgz#b3e034233188c68b889f5b862415306f565e2c56"


### PR DESCRIPTION
*Issue #, if available:*

GHSA-p6mc-m468-83gw
low severity
Vulnerable versions: < 4.17.19
Patched version: 4.17.19

Versions of lodash prior to 4.17.19 are vulnerable to Prototype Pollution. The function zipObjectDeep allows a malicious user to modify the prototype of Object if the property identifiers are user-supplied. Being affected by this issue requires zipping objects based on user-provided property arrays.

This vulnerability causes the addition or modification of an existing property that will exist on all objects and may lead to Denial of Service or Code Execution under specific circumstances.


*Description of changes:*
Updated lodash version in package.json to ^4.17.19

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
