### PR TITLE
Ui improvement2

### DIFF
--- a/app/lambda/get_session_data/lambda_function.py
+++ b/app/lambda/get_session_data/lambda_function.py
@@ -17,7 +17,7 @@ class GetSessionDataLambda(LambdaBase):
     def handle(self, event, context):
         try:
             sessionId = event['queryStringParameters'][DATASTORE_COLUMN_SESSION_ID].strip() if DATASTORE_COLUMN_SESSION_ID in event['queryStringParameters'] else None
-            if sessionId is None or sessionId == '' or sessionId[:2] != 's-':
+            if sessionId is None or sessionId[:2] != 's-':
                 return sendResponse(400, {'message':  DATASTORE_COLUMN_SESSION_ID + " has incorrect format"})
 
             bucket = os.environ['BUCKET_NAME']

--- a/app/lambda/get_session_data/lambda_function.py
+++ b/app/lambda/get_session_data/lambda_function.py
@@ -21,8 +21,6 @@ class GetSessionDataLambda(LambdaBase):
                 return sendResponse(400, {'message':  DATASTORE_COLUMN_SESSION_ID + " has incorrect format"})
 
             bucket = os.environ['BUCKET_NAME']
-            (print(bucket))
-            print(os.environ['AWS_REGION'])
             comprehend_key = self.getKeyName(sessionId,'comprehend','json')
             transcribe_key = self.getKeyName(sessionId,'transcribe','txt')
             client = boto3.client('s3', region_name=os.environ['AWS_REGION'])

--- a/app/lambda/get_session_data/lambda_function.py
+++ b/app/lambda/get_session_data/lambda_function.py
@@ -11,28 +11,18 @@ class GetSessionDataLambda(LambdaBase):
     def __init__(self): 
         pass
 
-    def putItem(self, PatientId, HealthCareProfessionalId, SessionName, SessionId, TimeStampStart, TimeStampEnd, TranscribeS3Path, ComprehendS3Path):
-        info = {DATASTORE_COLUMN_SESSION_ID : SessionId,
-                DATASTORE_COLUMN_PATIENT_ID: PatientId,
-                DATASTORE_COLUMN_HEALTH_CARE_PROFESSSIONAL_ID: HealthCareProfessionalId,
-                DATASTORE_COLUMN_SESSION_NAME: SessionName,
-                DATASTORE_COLUMN_COMPREHEND_S3_PATH: ComprehendS3Path,
-                DATASTORE_COLUMN_TRANSCRIBE_S3_PATH: TranscribeS3Path,
-                DATASTORE_COLUMN_TIMESTAMP_START: TimeStampStart,
-                DATASTORE_COLUMN_TIMESTAMP_END: TimeStampEnd}
-        Session().createSession(info)
-        return SessionId
-
     def getKeyName(self, sessionId, category, fileType):
         return 'public/'+category+'-medical-output/'+sessionId+'/'+sessionId+'-session-'+category+'.'+fileType
 
     def handle(self, event, context):
         try:
             sessionId = event['queryStringParameters'][DATASTORE_COLUMN_SESSION_ID].strip() if DATASTORE_COLUMN_SESSION_ID in event['queryStringParameters'] else None
-            if SessionId is None or SessionId == '' or SessionId[:2] != 'h-':
+            if sessionId is None or sessionId == '' or sessionId[:2] != 's-':
                 return sendResponse(400, {'message':  DATASTORE_COLUMN_SESSION_ID + " has incorrect format"})
 
             bucket = os.environ['BUCKET_NAME']
+            (print(bucket))
+            print(os.environ['AWS_REGION'])
             comprehend_key = self.getKeyName(sessionId,'comprehend','json')
             transcribe_key = self.getKeyName(sessionId,'transcribe','txt')
             client = boto3.client('s3', region_name=os.environ['AWS_REGION'])

--- a/app/package.json
+++ b/app/package.json
@@ -10,9 +10,9 @@
   },
   "stack": {
     "stackname": "MTA",
-    "region": "us-west-2"
+    "region": "%%REGION%%"
   },
-  "email": "ruilz@amazon.com",
+  "email": "%%USER_EMAIL%%",
   "scripts": {
     "bootstrap": "AWS_REGION=$npm_package_stack_region USER_EMAIL=$npm_package_email cdk bootstrap --toolkit-stack-name MedicalTranscriptionAnalysisCDKToolkit",
     "build-app": "react-scripts build",

--- a/app/package.json
+++ b/app/package.json
@@ -10,9 +10,9 @@
   },
   "stack": {
     "stackname": "MTA",
-    "region": "%%REGION%%"
+    "region": "us-west-2"
   },
-  "email": "%%USER_EMAIL%%",
+  "email": "ruilz@amazon.com",
   "scripts": {
     "bootstrap": "AWS_REGION=$npm_package_stack_region USER_EMAIL=$npm_package_email cdk bootstrap --toolkit-stack-name MedicalTranscriptionAnalysisCDKToolkit",
     "build-app": "react-scripts build",

--- a/app/src/Routes.js
+++ b/app/src/Routes.js
@@ -3,6 +3,7 @@ import { Route, Switch } from "react-router-dom";
 import Login from "./Login";
 import Home from "./home";
 import PreHome from "./preHome"
+import Export from "./export"
 import AuthenticatedRoute from "./AuthenticatedRoute";
 import UnauthenticatedRoute from "./UnauthenticatedRoute";
 
@@ -17,6 +18,9 @@ export default function Routes() {
       </AuthenticatedRoute>
       <AuthenticatedRoute exact path="/search">
         <PreHome/>
+      </AuthenticatedRoute>
+      <AuthenticatedRoute path="/export/:sid">
+        <Export/>
       </AuthenticatedRoute>
     </Switch>
   );

--- a/app/src/export.js
+++ b/app/src/export.js
@@ -1,0 +1,204 @@
+import React, { useState, useEffect } from 'react';
+import { BrowserRouter as Router, useHistory, useParams } from "react-router-dom";
+import { API, Auth } from "aws-amplify";
+import s from "./export.module.css";
+import {Table} from 'react-bootstrap';
+
+export default function Export(){
+    let params = useParams();
+    const [transcribeText, setTranscribeText] = useState([])
+    const [comprehendDict, setComprehendDict] = useState({})
+    const [updated, setUpdated] = useState(false)
+
+    useEffect(()=>{
+        async function loadS3Content(sessionId){
+            const apiName = 'MTADemoAPI';
+            const path = 'getTranscriptionComprehend';
+            const myInit = {
+                response: true,
+                queryStringParameters: {'SessionId': sessionId }
+            }
+            const result =  await API.get(apiName, path, myInit);
+            const transcribe = result['data']['transcribe']
+            const comprehend = result['data']['comprehend']
+            setTranscribeText(transcribe.split('.'))
+            setComprehendDict(JSON.parse(comprehend))
+            setUpdated(true)
+        }
+        loadS3Content(params.sid);
+    },[params.sid]);
+
+    const SessionSection = () => {
+        console.log(comprehendDict)
+        const Session = comprehendDict.Session
+
+        return (
+            <div className={s.session}>
+                <main>
+                    
+                    <Table className={s.ses} bordered striped small>
+                        <thead>
+                            <tr>
+                                <td colSpan='5'><h3>Session Overview</h3></td>
+                            </tr>
+                            <tr>
+                                <th>Session Id</th>
+                                <td className={s.spec}>{Session.sessionId}</td>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            
+                            <tr>
+                                <th>Patient Id </th>
+                                <td>{Session.patientId}</td>
+                            </tr>
+                            <tr>
+                                <th>Health Care Professional Id</th>
+                                <td>{Session.healthCareProfessionalId}</td>
+                            </tr>
+                            <tr>
+                                <th>Timestamp Start </th>
+                                <td>{Session.timeStampStart}</td>
+                            </tr>
+                            <tr>
+                                <th>Timestamp End</th>
+                                <td>{Session.timeStampEnd}</td>
+                            </tr>
+                        </tbody>
+                    </Table>
+                </main>
+            </div>
+        )
+
+    }   
+
+    const TranscribeSection = () => (
+        <div className={s.transcribe}> 
+            <h2>Session Transcription</h2>
+            {transcribeText.map( (text) => 
+                { return text ? <p>{text+'.'}</p> : null}
+            )}
+        </div>
+    )
+
+    const ComprehendSection = () => {
+        const Medication = comprehendDict.Medication
+        const RxNorm = comprehendDict.RxNorm
+        const MedicationRxNorm = comprehendDict.MedicationRxNorm
+        const MedicalCondition = comprehendDict.MedicalCondition
+        const ICD10CMConcept = comprehendDict.ICD10CMConcept
+        const MedicalConditionICD10CMConcept = comprehendDict.MedicalConditionICD10CMConcept
+        const TestTreatmentProcedures = comprehendDict.TestTreatmentProcedures
+    
+        return (
+            <div className={s.comprehend}>
+                <main>
+                
+                        <Table className={s.tests} bordered striped >
+                            <thead>
+                                <tr>
+                                    <td colSpan='3'><h3>Tests, Treatments, Procedures </h3></td>
+                                </tr>
+                                <tr>
+                                    <th>#</th>
+                                    <th>Text of Treatment</th>
+                                    <th>Type of Treatment</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                            {Object.values(TestTreatmentProcedures).map((tDict,idx) => (
+                                <tr>
+                                    <td>{idx+1}</td>
+                                    <td>{tDict.testTreatmentProcedureText}</td>
+                                    <td>{tDict.testTreatmentProcedureType}</td>
+                                </tr>
+                            ))}
+                            </tbody>
+                        </Table>
+                   
+                    <Table className={s.meds} bordered striped >
+                        <thead>
+                            <tr>
+                                <td colSpan='5'><h3>Medications</h3></td>
+                            </tr>
+                            <tr>
+                                <th>#</th>
+                                <th>Medication</th>
+                                <th>Medication Type</th>
+                                <th>RxNorm Code</th>
+                                <th>RxNorm Concept Text</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                        {Object.values(Medication).map((mDict,idx) => (
+                            <tr>
+                                <td>{idx+1}</td>
+                                <td>{mDict.medicationText}</td>
+                                <td>{mDict.medicationType}</td>
+                                <td>
+                                    {Object.values(MedicationRxNorm).filter(d=>d.medicationId===mDict.medicationId).map(mrnDict => (
+                                        <div>{mrnDict.code}</div>
+                                    ))}
+                                </td>
+                                <td>
+                                    {Object.values(MedicationRxNorm).filter(d=>d.medicationId===mDict.medicationId).map(mrnDict => (
+                                        <div>{Object.values(RxNorm).filter(d=>d.code===mrnDict.code)[0].description}</div>
+                                    ))}
+                                </td>
+                            </tr>
+                        ))}
+                        </tbody>
+                    </Table>
+
+                    
+                    <Table className={s.conds} bordered striped >
+                        <thead>
+                            <tr>
+                                <td colSpan='4'><h3>Medical Conditions</h3></td>
+                            </tr>
+                            <tr>
+                                <th>#</th>
+                                <th>Medical Condition</th>
+                                <th>ICD-10-CM Concept Code</th>
+                                <th>ICD-10-CM Concept Text</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            
+                        {Object.values(MedicalCondition).map((mcDict, idx) => (
+                            <tr>
+                                <td>{idx+1}</td>
+                                <td>{ mcDict.medicalConditionText }</td>
+                                <td>
+                                    {Object.values(MedicalConditionICD10CMConcept).filter(d=>d.medicalConditionId===mcDict.medicalConditionId).map(mciDict => (
+                                        <div>{mciDict.code}</div>
+                                    ))}
+                                </td>
+                                <td>
+                                    {Object.values(MedicalConditionICD10CMConcept).filter(d=>d.medicalConditionId===mcDict.medicalConditionId).map(mciDict => (  
+                                        <div>{(Object.values(ICD10CMConcept).filter(d=>d.code===mciDict.code)[0].description)}</div>
+                                    ))}
+                                </td>
+                            </tr>
+                        ))}
+                        </tbody>
+                    </Table>
+
+                </main>
+            </div>
+        )
+    }
+
+    return (
+        <div className={s.body}>
+            {updated && 
+            <div className={s.container}>
+                <SessionSection></SessionSection>
+                <TranscribeSection></TranscribeSection>
+                <ComprehendSection></ComprehendSection>
+            </div>}
+    
+        </div>
+        
+    )
+}

--- a/app/src/export.js
+++ b/app/src/export.js
@@ -29,7 +29,6 @@ export default function Export(){
     },[params.sid]);
 
     const SessionSection = () => {
-        console.log(comprehendDict)
         const Session = comprehendDict.Session
 
         return (

--- a/app/src/export.module.css
+++ b/app/src/export.module.css
@@ -1,0 +1,52 @@
+.body{
+    margin-top: -50px;
+    background-color: #ddd;
+    overflow: auto;
+    position: relative;
+    height: auto;
+    min-height: 100% !important;
+}
+
+.container{
+    margin: 5vw;
+    /* width: 60vw; */
+    /* height: 80vw; */
+    overflow: auto;
+    background: #fff;
+    padding: 5vw;
+    box-sizing: border-box;
+    box-shadow: 0 1vw 3vw rgba(0, 0, 0, 0.3);
+    font-size: .88vw;
+}
+
+thead .spec {
+    background-color: white;;
+}
+
+thead td{
+    background-color: rgba(0,0,0,.05);
+}
+
+thead h2{
+    margin: 0.2em;
+    float:left;
+}
+
+thead h3{
+    /* float: left; */
+    margin: 0;
+}
+
+.session table{
+    width: 50%;
+    margin: 40px auto;
+}
+
+h2{
+    margin-top: 50px;
+    margin-bottom: 30px;
+}
+
+.transcribe p{
+    font-size: 1vw;
+}

--- a/app/src/home.js
+++ b/app/src/home.js
@@ -170,7 +170,7 @@ export default function Home() {
   const [showForm, setShowForm] = useState(false)
   const [showSaveSessionButton, setShowSaveSessionButton] = useState(false)
   const [showCreateSessionSuccess, setShowCreateSessionSuccess] = useState(false)
-  const [SessionId, setSessionId] = useState('')
+  const [sid, setSessionId] = useState('')
   const [sessionValidated, setSessionValidated] = useState(false);
   const [patientValidated, setPatientValidated] = useState(false);
   const [healthCareProfessionalValidated, setHealthCareProfessionalValidated] = useState(false);
@@ -304,9 +304,9 @@ export default function Home() {
   }
 
   const handleSessionSubmit = (event) => {
+    event.preventDefault();
     const form = event.currentTarget;
     if (form.checkValidity() === false) {
-      event.preventDefault();
       event.stopPropagation();
       setSessionValidated(true);
     }else{
@@ -478,7 +478,7 @@ export default function Home() {
 
   const saveSession = () => {
     sessionId = 's-'+timeStampEnd+generate();
-    setSessionId(SessionId);
+    setSessionId(sessionId);
     Storage.configure({
       bucket: process.env.REACT_APP_StorageS3BucketName,
       level: 'public',
@@ -726,18 +726,6 @@ export default function Home() {
                 <Button variant="primary" type="submit">Submit</Button>  
             </Form>
           }
-          {/* {showCreateSessionForm && 
-            <form>
-              <input type="text" placeholder="Session Name" name="sessionName" value={sessionName} onChange={e => setSessionName(e.target.value)}/>
-              <p></p>
-              <input type="text" placeholder="Patient Id" name="patientId" value={patientId} onChange={e => setPatientId(e.target.value)}/>
-              <p href="#" onClick={patientShow}>new patient?</p>
-              <input type="text" placeholder="Health Care Professional Id" name="healthCareProfessionalId" value={healthCareProfessionalId} onChange={e => setHealthCareProfessionalId(e.target.value)}/>
-              <p href="#" onClick={healthCareProfessionalShow}>new health care professional?</p>
-              <button type="submit" onClick={()=>{setShowCreateSessionForm(!showCreateSessionForm);toggleShowForm()}}>Back</button>
-              <button type="submit" onClick={handleSessionSubmit}>Submit</button>
-            </form>
-          } */}
 
           {showCreatePatientForm &&  
             <Form noValidate validated={patientValidated} onSubmit={handleCreatePatient}>
@@ -806,7 +794,7 @@ export default function Home() {
           {showCreateSessionSuccess &&
           <div>
             <h2>Create Session Success!</h2>
-            <p>The Session Id is {SessionId}.</p>
+            <p>The Session Id is {sid}.</p>
             <p>Remember to save it :)</p>
             <button onClick={()=>{toggleCreateSessionSuccess();toggleShowForm()}}>Close</button>
           </div>}

--- a/app/src/preHome.js
+++ b/app/src/preHome.js
@@ -70,8 +70,7 @@ export default function PreHome() {
     }
 
     const handleTableCellClick = (sessionId) => {
-        alert(sessionId)
-        listS3Content(sessionId)
+        window.open('/export/'+sessionId, '_blank');
     }
 
     async function listS3Content(sessionId){
@@ -79,10 +78,11 @@ export default function PreHome() {
       const path = 'getTranscriptionComprehend';
       const myInit = {
         response: true,
-        queryStringParameters: {'sessionId': sessionId }
+        queryStringParameters: {'SessionId': sessionId }
       }
       const result =  await API.get(apiName, path, myInit);
-      console.log(result)
+      const transcribe = result['data']['transcribe']
+      const comprehend = JSON.parse(result['data']['comprehend'])
       return result
     }
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Refining UI Pieces:
1. User Flow Change - When user clicks the session name in table in search page, it will lead to the export page.
2. New Component Added - Added a new page called export that when user clicks the table cell, it shows the session, transcribe, and comprehend data from S3.
3. Added New CSS Styles.
4. New Functionality Added - Showed the session id when create session successful.

Backend:
1. Refined getTranscribeComprehend API

Next Steps:
1. Once Athena deployment is done, we can look at integrating the export page more seamlessly into MTA.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
