### PR TITLE
Fix installation by removing preinstall script

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -24,7 +24,6 @@
     "deploy": "yarn compile-stacks && yarn bootstrap && yarn deploy:backend && yarn pre-build && yarn deploy:client",
     "destroy": "STACKNAME=$npm_package_stack_stackname AWS_REGION=$npm_package_stack_region cdk destroy -v true -a \"node bin/deploy-client-stack.js\" && STACKNAME=$npm_package_stack_stackname AWS_REGION=$npm_package_stack_region USER_EMAIL=$npm_package_email cdk destroy -v true",
     "pre-build": "STACKNAME=$npm_package_stack_stackname AWS_REGION=$npm_package_stack_region node ./bin/pre-build.js",
-    "preinstall": "npx npm-force-resolutions",
     "test": "jest && react-scripts test",
     "update-client-stack-variables": "bash bin/stack-variables-to-client.sh",
     "watch": "tsc -w",


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The recently added preinstall script is only valid for `npm` but the project uses `yarn`, breaking the installation process. The purpose of this script is to mimic what `yarn` does with the resolutions field without the need of the preinstall script.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
