### PR TITLE
Cloudfront 404 redirect

### DIFF
--- a/app/lib/medical-transcription-analysis-stack.ts
+++ b/app/lib/medical-transcription-analysis-stack.ts
@@ -110,6 +110,14 @@ export class MedicalTranscriptionAnalysisStack extends cdk.Stack {
                 },
               }
             ],
+            errorConfigurations: [
+              {
+                errorCode: 404,
+                responseCode: 200,
+                errorCachingMinTtl: 5,
+                responsePagePath: "/index.html",
+              },
+            ],
             priceClass: PriceClass.PRICE_CLASS_100,
             httpVersion: HttpVersion.HTTP2,
             enableIpV6: true,

--- a/app/package.json
+++ b/app/package.json
@@ -24,7 +24,6 @@
     "deploy": "yarn compile-stacks && yarn bootstrap && yarn deploy:backend && yarn pre-build && yarn deploy:client",
     "destroy": "STACKNAME=$npm_package_stack_stackname AWS_REGION=$npm_package_stack_region cdk destroy -v true -a \"node bin/deploy-client-stack.js\" && STACKNAME=$npm_package_stack_stackname AWS_REGION=$npm_package_stack_region USER_EMAIL=$npm_package_email cdk destroy -v true",
     "pre-build": "STACKNAME=$npm_package_stack_stackname AWS_REGION=$npm_package_stack_region node ./bin/pre-build.js",
-    "preinstall": "npx npm-force-resolutions",
     "test": "jest && react-scripts test",
     "update-client-stack-variables": "bash bin/stack-variables-to-client.sh",
     "watch": "tsc -w",


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Since the application uses client side routing, visiting any page besides the home page directly. This PR adds a cloudfront level redirect back to the home page for 404s.

Based off #45 as that fix is also required to fix the build.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
