### PR TITLE
Fix speaker diarization bugs

### DIFF
--- a/app/src/components/ExportPane.js
+++ b/app/src/components/ExportPane.js
@@ -96,7 +96,9 @@ const getExportSections = ({ resultChunks, excludedItems, soapSummary, transcrip
       },
       content: [
         'Below is the transcription for your visit',
-        ...(transcriptChunks ? transcriptChunks : []).map((chunk) => chunk.text),
+        ...(transcriptChunks ? transcriptChunks : []).map(({ speaker, text }) =>
+          speaker ? `${speaker}\n${text}` : text,
+        ),
       ],
     },
   ];

--- a/app/src/components/TranscriptLine.js
+++ b/app/src/components/TranscriptLine.js
@@ -3,7 +3,7 @@ import s from './TranscriptLine.module.css';
 import cs from 'clsx';
 
 import classMap from '../transcriptHighlights';
-import { Editable, EditableInput } from '@chakra-ui/react';
+import { Editable, EditableInput, Box } from '@chakra-ui/react';
 
 // Reduces results down to a single set of non-overlapping ranges, each with a list of applicable results
 function combineSegments(results) {
@@ -106,9 +106,12 @@ export default function TranscriptLine({
           onSubmit={(nextValue) => {
             handleTranscriptChange(nextValue.trim());
           }}
+          mb={8}
         >
           {({ isEditing, onEdit }) => (
             <>
+              {chunk.speaker && <div>{chunk.speaker}</div>}
+
               <EditableInput />
               {!isEditing && (
                 <p className={s.base} onClick={onEdit}>
@@ -125,13 +128,15 @@ export default function TranscriptLine({
       )}
 
       {!enableEditing && (
-        <p className={s.base}>
+        <Box as='p' className={s.base} mb={8}>
+          {chunk.speaker && <div>{chunk.speaker}</div>}
+
           {ranges.map((r, i) => (
             <span key={i} className={cs(r.matches.map((x) => classMap[x.Category]))}>
               {r.text}
             </span>
           ))}
-        </p>
+        </Box>
       )}
     </React.Fragment>
   );

--- a/app/src/components/TranscriptLine.module.css
+++ b/app/src/components/TranscriptLine.module.css
@@ -1,7 +1,6 @@
 .base {
   line-height: 1.6;
   white-space: pre-wrap;
-  margin: 1em 0;
   transition: margin 300ms ease;
 }
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Bugs fixed:
- Speaker attribution being part of the `text` string on a line object makes it susceptible to detection as an entity and also becomes editable
- New speaker attributions in the middle of sentences
- Spaces between words and punctuation marks

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
